### PR TITLE
Pin `numpy` to `1.26.4`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ If you have any questions about Galadriel, feel free to do:
 
 * [Join our Discord](https://discord.com/invite/bHnFgSTKrP) and ask for help.
 * Report bugs or feature requests in [GitHub issues](https://github.com/galadriel-ai/contracts/issues).
+.

--- a/README.md
+++ b/README.md
@@ -66,4 +66,3 @@ If you have any questions about Galadriel, feel free to do:
 
 * [Join our Discord](https://discord.com/invite/bHnFgSTKrP) and ask for help.
 * Report bugs or feature requests in [GitHub issues](https://github.com/galadriel-ai/contracts/issues).
-.

--- a/oracles/requirements.txt
+++ b/oracles/requirements.txt
@@ -1,4 +1,5 @@
 backoff==2.2.1
+numpy==1.26.4
 faiss-cpu==1.8.0
 openai==1.11.1
 python-dotenv==1.0.1


### PR DESCRIPTION
`numpy` recently released version `2.0.0`, breaking some of the dependencies