### PR TITLE
Removed Unused Variable

### DIFF
--- a/contracts/contracts/OpenAiSimpleLlm.sol
+++ b/contracts/contracts/OpenAiSimpleLlm.sol
@@ -36,7 +36,6 @@ contract OpenAiSimpleLLM {
 
     // required for Oracle
     function onOracleOpenAiLlmResponse(
-        uint runId,
         IOracle.OpenAiResponse memory _response,
         string memory _errorMessage
     ) public {


### PR DESCRIPTION
Removed unused variable "uint runId" giving unnecessary warning.


Original Function Signature: 
```
function onOracleOpenAiLlmResponse(
        uint runId,
        IOracle.OpenAiResponse memory _response,
        string memory _errorMessage
    )
```
    
ps: just making this pr cause it's irritating to see useless warnings :)