### PR TITLE
Update README and clarify `.env.template` configuration steps

### DIFF
--- a/oracles/README.md
+++ b/oracles/README.md
@@ -18,13 +18,22 @@ Ensure that your Oracle smart contract is deployed and your wallet address is [w
 
 ### Configuration
 
-Create a `.env` file in the project root with the content updated to your values:
+Before starting the project, you need to configure the necessary environment variables.
+
+1. Copy the `.env.template` file into a new `.env` file at the root of the project:
+
+   ```shell
+   cp .env.template .env
+   ```
+
+2. Open the .env file and update the values with your specific information:
 
 ```plaintext
 PRIVATE_KEY="[whitelisted wallet private key]"
 ORACLE_ADDRESS="[oracle smart contract address]"
 OPEN_AI_API_KEY="[openai api key]"
 SERPER_API_KEY="[serper api key]"
+PINATA_API_JWT="[pinata API JWT]"
 ```
 
 For more configuration parameters, see [template.env](https://github.com/galadriel-ai/contracts/blob/main/oracles/template.env)

--- a/oracles/template.env
+++ b/oracles/template.env
@@ -1,25 +1,34 @@
-# "local" or "production"
+# Specify the environment: "local" or "production"
 ENVIRONMENT="local"
 
+# API keys for various services. Make sure to add valid keys below.
 OPEN_AI_API_KEY="sk-"
 GROQ_API_KEY="gsk_"
 ANTHROPIC_API_KEY="sk-ant-"
-
 SERPER_API_KEY=""
 
-CHAIN_ID=31337
-WEB3_RPC_URL="http://127.0.0.1:8545/"
+# Blockchain settings
+CHAIN_ID=696969 # The Chain ID for the Galadriel network
+WEB3_RPC_URL="https://devnet.galadriel.com/"  # RPC URL for Galadriel devnet
+
+# Wallet and contract settings
 PRIVATE_KEY="0x"
 ORACLE_ADDRESS="0x"
 ORACLE_ABI_PATH="../contracts/artifacts/contracts/ChatOracle.sol/ChatOracle.json"
 
+# Google Cloud and external services
 GCS_BUCKET_NAME="galadriel-assets"
 E2B_API_KEY=""
-SERVE_METRICS="False"
+
+# Pinata configuration for managing assets
 PINATA_GATEWAY_TOKEN=""
 PINATA_API_JWT=""
 
+# Knowledge base settings
 # serialized knowledge base max size in bytes
 # 10 megabytes * 1024 * 1024
 KNOWLEDGE_BASE_MAX_SIZE_BYTES = 10485760
 KNOWLEDGE_BASE_CACHE_MAX_SIZE = 100
+
+# Serve metrics: "True" or "False"
+SERVE_METRICS="False"


### PR DESCRIPTION
- Add instructions to copy `.env.template` to `.env`
- Clarify the use of `PINATA_API_JWT` in the README
- Highlight the importance of deploying and configuring the Oracle smart contract
- Update `.env.template` for better clarity on required configuration parameters